### PR TITLE
Add Vercel config for static frontend

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "frontend/**", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "frontend/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- serve frontend directory on Vercel via static build and routing rules

## Testing
- `pytest` *(fails: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a25eb60adc832a87fbe70c30f14236