### PR TITLE
Handle fetch errors in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <h1>Re-Ly AI</h1>
+  <div id="error"></div>
   <section id="generator">
     <h2>Create Campaign</h2>
     <input id="goal" placeholder="Enter marketing goal" />

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,6 +1,13 @@
 let currentCampaignId = null;
 let selectedVariant = 'auto';
 
+function showError(message) {
+  const div = document.getElementById('error');
+  if (div) {
+    div.innerText = message;
+  }
+}
+
 async function generate() {
   const goal = document.getElementById('goal').value;
   const res = await fetch('/campaigns/generate', {
@@ -8,7 +15,13 @@ async function generate() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ goal })
   });
+  if (!res.ok) {
+    console.error('Request failed', res.status);
+    showError('Failed to generate campaign');
+    return;
+  }
   const data = await res.json();
+  showError('');
   currentCampaignId = data.campaign_id || 1; // placeholder
   const div = document.getElementById('variants');
   div.innerHTML = '';
@@ -22,16 +35,28 @@ async function generate() {
 
 async function sendSelected() {
   if (!currentCampaignId) return;
-  await fetch('/campaigns/send', {
+  const res = await fetch('/campaigns/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ campaign_id: currentCampaignId, variant: selectedVariant, contacts: [1] })
   });
+  if (!res.ok) {
+    console.error('Request failed', res.status);
+    showError('Failed to send campaign');
+    return;
+  }
+  showError('');
 }
 
 async function loadMetrics() {
   const res = await fetch('/dashboard');
+  if (!res.ok) {
+    console.error('Request failed', res.status);
+    showError('Failed to load metrics');
+    return;
+  }
   const data = await res.json();
+  showError('');
   const div = document.getElementById('metrics');
   div.innerText = `Sent last 7 days: ${data.messages_last_7_days}\nCTR: ${data.ctr}%\nOpt-outs: ${data.opt_outs}`;
 }


### PR DESCRIPTION
## Summary
- ensure all frontend fetch calls check `res.ok` before reading response
- display user-friendly errors in a dedicated `#error` element

## Testing
- `node --check frontend/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a261780118832a8e22a31fda5613d7