### PR TITLE
Move backend to serverless api

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -4,11 +4,11 @@ from sqlalchemy.orm import Session
 from datetime import datetime
 from typing import List
 
-from .database import Base, engine, get_db
-from . import schemas, crud, models
-from .openai_utils import generate_variants
-from .twilio_utils import send_sms
-from .scheduler import schedule
+from backend.database import Base, engine, get_db
+from backend import schemas, crud, models
+from backend.openai_utils import generate_variants
+from backend.twilio_utils import send_sms
+from backend.scheduler import schedule
 
 Base.metadata.create_all(bind=engine)
 

--- a/backend/tests/test_generate.py
+++ b/backend/tests/test_generate.py
@@ -1,10 +1,10 @@
 from fastapi.testclient import TestClient
 from unittest.mock import patch
-from backend.main import app
+from api.index import app
 
 client = TestClient(app)
 
-@patch("backend.main.generate_variants", return_value=["Hello A", "Hello B"])
+@patch("api.index.generate_variants", return_value=["Hello A", "Hello B"])
 def test_generate_campaign(mock_gen):
     response = client.post("/campaigns/generate", json={"goal": "sell"})
     assert response.status_code == 200

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,11 @@
 {
   "version": 2,
   "builds": [
-    { "src": "frontend/**", "use": "@vercel/static" }
+    { "src": "frontend/**", "use": "@vercel/static" },
+    { "src": "api/index.py", "use": "@vercel/python" }
   ],
   "routes": [
+    { "src": "/(campaigns|dashboard)(.*)", "dest": "/api$2" },
     { "src": "/(.*)", "dest": "frontend/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- expose FastAPI backend as a Vercel serverless function at `api/index.py`
- route campaign and dashboard requests to the serverless backend via `vercel.json`
- adjust unit test to import the new serverless module

## Testing
- `pytest backend/tests/test_generate.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi==0.110.0 sqlalchemy==2.0.25 uvicorn==0.23.2 -q` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*
- `npm install -g vercel` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68a2617af334832aa641242acedde33d