### PR TITLE
Display generated SMS below input

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,6 +12,7 @@
     <h2>Create Campaign</h2>
     <input id="goal" placeholder="Enter marketing goal" />
     <button onclick="generate()">Generate SMS</button>
+    <h3>Generated SMS</h3>
     <div id="variants"></div>
     <button onclick="sendSelected()">Send</button>
   </section>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -26,10 +26,14 @@ async function generate() {
   const div = document.getElementById('variants');
   div.innerHTML = '';
   data.variants.forEach(v => {
-    const btn = document.createElement('button');
-    btn.innerText = v.variant + ': ' + v.text;
-    btn.onclick = () => { selectedVariant = v.variant; };
-    div.appendChild(btn);
+    const p = document.createElement('p');
+    p.innerText = v.variant + ': ' + v.text;
+    p.onclick = () => {
+      selectedVariant = v.variant;
+      Array.from(div.children).forEach(c => c.classList.remove('selected'));
+      p.classList.add('selected');
+    };
+    div.appendChild(p);
   });
 }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,3 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 2rem; }
 button { margin: 0.5rem; }
-#variants button { display: block; }
+#variants p { cursor: pointer; margin: 0.25rem 0; }
+#variants p.selected { font-weight: bold; }


### PR DESCRIPTION
## Summary
- Show AI-generated SMS variants as selectable paragraphs beneath the generator input
- Highlight selected variant with basic styling and add heading for generated messages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a306bbd6f4832aa34dbe4f7697d48a