### PR TITLE
Graceful fallback when OpenAI API unavailable

### DIFF
--- a/backend/openai_utils.py
+++ b/backend/openai_utils.py
@@ -1,25 +1,56 @@
 import os
 from typing import List
 
-import openai
+# ``openai`` is an optional dependency during development/testing.  The
+# frontend calls the backend even when no OpenAI API key is configured which
+# would previously raise an exception and result in the "Failed to generate
+# campaign" error message.  Import ``openai`` defensively and fall back to a
+# simple variant generator when it is unavailable or an API error occurs.
+try:  # pragma: no cover - import failure is tested separately
+    import openai  # type: ignore
+except Exception:  # ImportError or any runtime error
+    openai = None  # type: ignore
 
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
-openai.api_key = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if openai and OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
 
 PROMPT_TEMPLATE = (
     "Generate two short SMS messages (max 160 characters) that achieve the goal: '{goal}'. "
     "Provide variants A and B. Messages must comply with SMS marketing rules."
 )
 
+def _fallback(goal: str) -> List[str]:
+    """Return simple placeholder messages."""
+    return [f"{goal} - option A", f"{goal} - option B"]
+
+
 def generate_variants(goal: str) -> List[str]:
+    """Generate two SMS variants for the given goal.
+
+    The function attempts to call the OpenAI API but gracefully falls back to
+    deterministic placeholder messages if the API is unavailable or returns an
+    unexpected response.  This prevents the frontend from showing an error
+    when the developer does not have an API key configured.
+    """
+
+    # If the OpenAI library or API key is missing, return the fallback variants
+    if not openai or not OPENAI_API_KEY:  # pragma: no cover - handled by tests
+        return _fallback(goal)
+
     prompt = PROMPT_TEMPLATE.format(goal=goal)
-    response = openai.ChatCompletion.create(
-        model=OPENAI_MODEL,
-        messages=[{"role": "user", "content": prompt}],
-        n=1,
-        temperature=0.7,
-    )
-    text = response.choices[0].message["content"]
+    try:
+        response = openai.ChatCompletion.create(  # type: ignore[attr-defined]
+            model=OPENAI_MODEL,
+            messages=[{"role": "user", "content": prompt}],
+            n=1,
+            temperature=0.7,
+        )
+        text = response.choices[0].message["content"]
+    except Exception:
+        return _fallback(goal)
+
     # Expect output like "A: message1\nB: message2"
     lines = [line.strip() for line in text.splitlines() if line.strip()]
     variants = []
@@ -27,6 +58,5 @@ def generate_variants(goal: str) -> List[str]:
         if line[0].upper() in ("A", "B"):
             variants.append(line.split(":", 1)[1].strip())
     if len(variants) < 2:
-        # Fallback simple messages
-        variants = [f"{goal} - option A", f"{goal} - option B"]
+        return _fallback(goal)
     return variants[:2]

--- a/backend/tests/test_openai_utils.py
+++ b/backend/tests/test_openai_utils.py
@@ -1,0 +1,8 @@
+from backend import openai_utils
+
+
+def test_generate_variants_fallback(monkeypatch):
+    # Simulate missing OpenAI dependency or API key
+    monkeypatch.setattr(openai_utils, "openai", None)
+    monkeypatch.setattr(openai_utils, "OPENAI_API_KEY", None)
+    assert openai_utils.generate_variants("sell") == ["sell - option A", "sell - option B"]

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -10,31 +10,32 @@ function showError(message) {
 
 async function generate() {
   const goal = document.getElementById('goal').value;
-  const res = await fetch('/campaigns/generate', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ goal })
-  });
-  if (!res.ok) {
-    console.error('Request failed', res.status);
+  try {
+    const res = await fetch('/campaigns/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ goal })
+    });
+    if (!res.ok) throw new Error(res.status);
+    const data = await res.json();
+    showError('');
+    currentCampaignId = data.campaign_id || 1; // placeholder
+    const div = document.getElementById('variants');
+    div.innerHTML = '';
+    data.variants.forEach(v => {
+      const p = document.createElement('p');
+      p.innerText = v.variant + ': ' + v.text;
+      p.onclick = () => {
+        selectedVariant = v.variant;
+        Array.from(div.children).forEach(c => c.classList.remove('selected'));
+        p.classList.add('selected');
+      };
+      div.appendChild(p);
+    });
+  } catch (e) {
+    console.error('Request failed', e);
     showError('Failed to generate campaign');
-    return;
   }
-  const data = await res.json();
-  showError('');
-  currentCampaignId = data.campaign_id || 1; // placeholder
-  const div = document.getElementById('variants');
-  div.innerHTML = '';
-  data.variants.forEach(v => {
-    const p = document.createElement('p');
-    p.innerText = v.variant + ': ' + v.text;
-    p.onclick = () => {
-      selectedVariant = v.variant;
-      Array.from(div.children).forEach(c => c.classList.remove('selected'));
-      p.classList.add('selected');
-    };
-    div.appendChild(p);
-  });
 }
 
 async function sendSelected() {
@@ -53,16 +54,20 @@ async function sendSelected() {
 }
 
 async function loadMetrics() {
-  const res = await fetch('/dashboard');
-  if (!res.ok) {
-    console.error('Request failed', res.status);
+  try {
+    const res = await fetch('/dashboard');
+    if (!res.ok) throw new Error(res.status);
+    const data = await res.json();
+    showError('');
+    const div = document.getElementById('metrics');
+    div.innerText = `Sent last 7 days: ${data.messages_last_7_days}\nCTR: ${data.ctr}%\nOpt-outs: ${data.opt_outs}`;
+  } catch (e) {
+    console.error('Request failed', e);
     showError('Failed to load metrics');
-    return;
+    // Populate with default values so the dashboard still renders
+    const div = document.getElementById('metrics');
+    div.innerText = 'Sent last 7 days: 0\nCTR: 0%\nOpt-outs: 0';
   }
-  const data = await res.json();
-  showError('');
-  const div = document.getElementById('metrics');
-  div.innerText = `Sent last 7 days: ${data.messages_last_7_days}\nCTR: ${data.ctr}%\nOpt-outs: ${data.opt_outs}`;
 }
 
 loadMetrics();


### PR DESCRIPTION
## Summary
- fall back to simple SMS templates when OpenAI API is missing or fails
- handle frontend request errors and display default dashboard metrics
- cover OpenAI fallback logic with a regression test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi==0.110.0 sqlalchemy==2.0.30 -q` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3086af1a0832a8e33ddf75c9bfd85