### PR TITLE
feat: add initial node backend with mongoose models

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "really-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts",
+    "test": "ts-node tests/e2e.test.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "mongoose": "^8.3.4",
+    "zod": "^3.22.4",
+    "cheerio": "^1.0.0-rc.12"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.19",
+    "@types/cheerio": "^0.22.33",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.4",
+    "mongodb-memory-server": "^8.12.1"
+  }
+}

--- a/server/scripts/init-db.ts
+++ b/server/scripts/init-db.ts
@@ -1,0 +1,26 @@
+import { connect, disconnect } from '../src/db.js';
+import {
+  Company,
+  Customer,
+  Campaign,
+  CampaignResult,
+  CampaignEvent,
+  WebSource,
+  WebDiff,
+} from '../src/models/index.js';
+
+async function run() {
+  await connect();
+  await Promise.all([
+    Company.syncIndexes(),
+    Customer.syncIndexes(),
+    Campaign.syncIndexes(),
+    CampaignResult.syncIndexes(),
+    CampaignEvent.syncIndexes(),
+    WebSource.syncIndexes(),
+    WebDiff.syncIndexes(),
+  ]);
+  await disconnect();
+}
+
+run();

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -1,0 +1,15 @@
+import { connect, disconnect } from '../src/db.js';
+import { Company, Customer } from '../src/models/index.js';
+
+async function run() {
+  await connect();
+  const company = await Company.create({ company_id: 'seedco', name: 'Seed Co' });
+  await Customer.insertMany([
+    { customer_id: 's1', company_id: company._id, phone: '+10000000001' },
+    { customer_id: 's2', company_id: company._id, phone: '+10000000002' },
+    { customer_id: 's3', company_id: company._id, phone: '+10000000003' },
+  ]);
+  await disconnect();
+}
+
+run();

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const uri = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/really';
+
+export async function connect() {
+  await mongoose.connect(uri);
+}
+
+export async function disconnect() {
+  await mongoose.disconnect();
+}
+
+export default mongoose;

--- a/server/src/models/campaign.ts
+++ b/server/src/models/campaign.ts
@@ -1,0 +1,15 @@
+import { Schema, model, Document } from 'mongoose';
+
+const CampaignSchema = new Schema(
+  {
+    campaign_id: { type: String, unique: true, index: true },
+    company_id: { type: Schema.Types.ObjectId, ref: 'Company', required: true },
+    brief: String,
+    message: String,
+    snapshot: Schema.Types.Mixed,
+  },
+  { timestamps: true }
+);
+
+export interface CampaignDoc extends Document {}
+export const Campaign = model<CampaignDoc>('Campaign', CampaignSchema);

--- a/server/src/models/campaign_event.ts
+++ b/server/src/models/campaign_event.ts
@@ -1,0 +1,20 @@
+import { Schema, model, Document } from 'mongoose';
+
+const CampaignEventSchema = new Schema(
+  {
+    campaign_id: { type: Schema.Types.ObjectId, ref: 'Campaign', required: true },
+    company_id: { type: Schema.Types.ObjectId, ref: 'Company', required: true },
+    type: { type: String, required: true },
+    occurred_at: { type: Date, default: Date.now },
+    metadata: Schema.Types.Mixed,
+  },
+  { timestamps: true }
+);
+
+CampaignEventSchema.index({ company_id: 1, occurred_at: -1 });
+
+export interface CampaignEventDoc extends Document {}
+export const CampaignEvent = model<CampaignEventDoc>(
+  'CampaignEvent',
+  CampaignEventSchema
+);

--- a/server/src/models/campaign_result.ts
+++ b/server/src/models/campaign_result.ts
@@ -1,0 +1,17 @@
+import { Schema, model, Document } from 'mongoose';
+
+const CampaignResultSchema = new Schema(
+  {
+    campaign_id: { type: Schema.Types.ObjectId, ref: 'Campaign', unique: true },
+    replies_7d: { type: Number, default: 0 },
+    clicks_7d: { type: Number, default: 0 },
+    bookings_7d: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+export interface CampaignResultDoc extends Document {}
+export const CampaignResult = model<CampaignResultDoc>(
+  'CampaignResult',
+  CampaignResultSchema
+);

--- a/server/src/models/company.ts
+++ b/server/src/models/company.ts
@@ -1,0 +1,36 @@
+import { Schema, model, Document } from 'mongoose';
+
+const LocationSchema = new Schema(
+  {
+    address: String,
+    hours: [String],
+  },
+  { _id: false }
+);
+
+const WebEnrichmentSchema = new Schema(
+  {
+    services: [String],
+    usps: [String],
+    social: [String],
+    review_themes: [String],
+    title: String,
+  },
+  { _id: false }
+);
+
+const CompanySchema = new Schema(
+  {
+    company_id: { type: String, unique: true, index: true },
+    name: String,
+    channels: [String],
+    brand_tone: String,
+    locales: [String],
+    locations: [LocationSchema],
+    web_enrichment: WebEnrichmentSchema,
+  },
+  { timestamps: true }
+);
+
+export interface CompanyDoc extends Document {}
+export const Company = model<CompanyDoc>('Company', CompanySchema);

--- a/server/src/models/customer.ts
+++ b/server/src/models/customer.ts
@@ -1,0 +1,28 @@
+import { Schema, model, Document } from 'mongoose';
+
+const OptInSchema = new Schema(
+  {
+    sms: { type: Boolean, default: false },
+    sms_ts: Date,
+    email: { type: Boolean, default: false },
+    email_ts: Date,
+  },
+  { _id: false }
+);
+
+const CustomerSchema = new Schema(
+  {
+    customer_id: { type: String, unique: true, index: true },
+    company_id: { type: Schema.Types.ObjectId, ref: 'Company', required: true },
+    name: String,
+    phone: String,
+    email: String,
+    opt_in: OptInSchema,
+  },
+  { timestamps: true }
+);
+
+CustomerSchema.index({ company_id: 1, phone: 1 }, { unique: true });
+
+export interface CustomerDoc extends Document {}
+export const Customer = model<CustomerDoc>('Customer', CustomerSchema);

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,0 +1,7 @@
+export * from './company';
+export * from './customer';
+export * from './campaign';
+export * from './campaign_result';
+export * from './campaign_event';
+export * from './web_source';
+export * from './web_diff';

--- a/server/src/models/web_diff.ts
+++ b/server/src/models/web_diff.ts
@@ -1,0 +1,19 @@
+import { Schema, model, Document } from 'mongoose';
+
+const WebDiffSchema = new Schema(
+  {
+    diff_id: { type: String, unique: true, index: true },
+    company_id: { type: Schema.Types.ObjectId, ref: 'Company', required: true },
+    source_id: { type: Schema.Types.ObjectId, ref: 'WebSource', required: true },
+    diff: Schema.Types.Mixed,
+    status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
+    detected_at: { type: Date, default: Date.now },
+    applied_at: Date,
+  },
+  { timestamps: true }
+);
+
+WebDiffSchema.index({ company_id: 1, status: 1, detected_at: -1 });
+
+export interface WebDiffDoc extends Document {}
+export const WebDiff = model<WebDiffDoc>('WebDiff', WebDiffSchema);

--- a/server/src/models/web_source.ts
+++ b/server/src/models/web_source.ts
@@ -1,0 +1,18 @@
+import { Schema, model, Document } from 'mongoose';
+
+const WebSourceSchema = new Schema(
+  {
+    source_id: { type: String, unique: true, index: true },
+    company_id: { type: Schema.Types.ObjectId, ref: 'Company', required: true },
+    kind: { type: String, required: true },
+    url: { type: String, required: true },
+    etag: String,
+    last_checked: Date,
+  },
+  { timestamps: true }
+);
+
+WebSourceSchema.index({ company_id: 1, kind: 1 });
+
+export interface WebSourceDoc extends Document {}
+export const WebSource = model<WebSourceDoc>('WebSource', WebSourceSchema);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,216 @@
+import express from 'express';
+import { z } from 'zod';
+import { connect } from './db.js';
+import {
+  Company,
+  Customer,
+  Campaign,
+  CampaignEvent,
+  CampaignResult,
+  WebSource,
+  WebDiff,
+} from './models/index.js';
+import { randomUUID } from 'crypto';
+
+const app = express();
+app.use(express.json());
+
+// save_company_profile
+const companySchema = z.object({
+  company_id: z.string(),
+  name: z.string(),
+  channels: z.array(z.string()).optional(),
+  brand_tone: z.string().optional(),
+  locales: z.array(z.string()).optional(),
+  locations: z
+    .array(
+      z.object({
+        address: z.string(),
+        hours: z.array(z.string()).optional(),
+      })
+    )
+    .optional(),
+});
+
+app.post('/save_company_profile', async (req, res) => {
+  try {
+    const data = companySchema.parse(req.body);
+    const doc = await Company.findOneAndUpdate(
+      { company_id: data.company_id },
+      data,
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    ).lean();
+    res.json(doc);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// save_customer
+const customerSchema = z.object({
+  customer_id: z.string(),
+  company_id: z.string(),
+  name: z.string().optional(),
+  phone: z.string().optional(),
+  email: z.string().optional(),
+  opt_in: z
+    .object({
+      sms: z.boolean().optional(),
+      sms_ts: z.string().datetime().optional(),
+      email: z.boolean().optional(),
+      email_ts: z.string().datetime().optional(),
+    })
+    .optional(),
+});
+
+app.post('/save_customer', async (req, res) => {
+  try {
+    const data = customerSchema.parse(req.body);
+    const doc = await Customer.findOneAndUpdate(
+      { customer_id: data.customer_id },
+      data,
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    ).lean();
+    res.json(doc);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// record_campaign
+const campaignSchema = z.object({
+  company_id: z.string(),
+  campaign_id: z.string().optional(),
+  brief: z.string().optional(),
+  message: z.string().optional(),
+});
+
+app.post('/record_campaign', async (req, res) => {
+  try {
+    const data = campaignSchema.parse(req.body);
+    const campaign_id = data.campaign_id || randomUUID();
+    const campaign = await Campaign.create({ ...data, campaign_id });
+    await CampaignEvent.create({
+      campaign_id: campaign._id,
+      company_id: campaign.company_id,
+      type: 'campaign_created',
+    });
+    res.json({ campaign_id });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// record_campaign_results
+const resultSchema = z.object({
+  campaign_id: z.string(),
+  replies_7d: z.number().default(0),
+  clicks_7d: z.number().default(0),
+  bookings_7d: z.number().default(0),
+});
+
+app.post('/record_campaign_results', async (req, res) => {
+  try {
+    const data = resultSchema.parse(req.body);
+    const campaign = await Campaign.findOne({ campaign_id: data.campaign_id });
+    if (!campaign) return res.status(404).json({ error: 'campaign not found' });
+    await CampaignResult.findOneAndUpdate(
+      { campaign_id: campaign._id },
+      { ...data, campaign_id: campaign._id },
+      { upsert: true }
+    );
+    res.json({ status: 'ok' });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// start_web_enrichment
+const enrichmentSchema = z.object({
+  company_id: z.string(),
+  sources: z.array(z.object({ kind: z.string(), url: z.string().url() })),
+});
+
+app.post('/start_web_enrichment', async (req, res) => {
+  try {
+    const data = enrichmentSchema.parse(req.body);
+    const company = await Company.findOne({ company_id: data.company_id });
+    if (!company) return res.status(404).json({ error: 'company not found' });
+    for (const src of data.sources) {
+      await WebSource.create({
+        source_id: randomUUID(),
+        company_id: company._id,
+        kind: src.kind,
+        url: src.url,
+      });
+    }
+    res.json({ status: 'queued', sources: data.sources.length });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// list_web_diffs
+const listDiffsSchema = z.object({ company_id: z.string() });
+app.get('/list_web_diffs', async (req, res) => {
+  try {
+    const data = listDiffsSchema.parse(req.query);
+    const company = await Company.findOne({ company_id: data.company_id });
+    if (!company) return res.status(404).json({ error: 'company not found' });
+    const diffs = await WebDiff.find({ company_id: company._id, status: 'pending' })
+      .lean();
+    res.json(diffs);
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// apply_web_diff
+const applyDiffSchema = z.object({ action: z.enum(['approve', 'reject']) });
+app.post('/apply_web_diff/:id', async (req, res) => {
+  try {
+    const data = applyDiffSchema.parse(req.body);
+    const diff = await WebDiff.findOne({ diff_id: req.params.id });
+    if (!diff) return res.status(404).json({ error: 'diff not found' });
+    diff.status = data.action === 'approve' ? 'approved' : 'rejected';
+    if (data.action === 'approve') {
+      diff.applied_at = new Date();
+      await Company.findByIdAndUpdate(diff.company_id, { web_enrichment: diff.diff });
+    }
+    await diff.save();
+    res.json({ status: diff.status });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// get_policy_status
+const policySchema = z.object({ company_id: z.string(), channel: z.string() });
+app.get('/get_policy_status', async (req, res) => {
+  try {
+    const data = policySchema.parse(req.query);
+    res.json({
+      company_id: data.company_id,
+      channel: data.channel,
+      quiet_hours: '21:00-08:00',
+      max_per_week: 3,
+      opt_in_required: true,
+    });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+export async function start() {
+  await connect();
+  const port = process.env.PORT || 3000;
+  return app.listen(port, () => {
+    console.log(`Server running on ${port}`);
+  });
+}
+
+if (process.env.RUN_SERVER) {
+  start();
+}
+
+export default app;

--- a/server/tests/e2e.test.ts
+++ b/server/tests/e2e.test.ts
@@ -1,0 +1,76 @@
+import request from 'supertest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import app from '../src/server.js';
+import { CampaignEvent, Campaign } from '../src/models/index.js';
+
+async function main() {
+  const mongo = await MongoMemoryServer.create();
+  const uri = mongo.getUri();
+  process.env.MONGO_URI = uri;
+  await mongoose.connect(uri);
+
+  const agent = request(app);
+
+  await agent
+    .post('/save_company_profile')
+    .send({ company_id: 'c1', name: 'Acme' })
+    .expect(200);
+
+  for (let i = 0; i < 3; i++) {
+    await agent
+      .post('/save_customer')
+      .send({
+        customer_id: `cust${i}`,
+        company_id: 'c1',
+        phone: `+1000000000${i}`,
+      })
+      .expect(200);
+  }
+
+  await agent
+    .post('/start_web_enrichment')
+    .send({
+      company_id: 'c1',
+      sources: [{ kind: 'website', url: 'https://example.com' }],
+    })
+    .expect(200);
+
+  // run worker
+  await import('../worker/enrichment.js');
+
+  const list = await agent
+    .get('/list_web_diffs')
+    .query({ company_id: 'c1' })
+    .expect(200);
+  const diffId = list.body[0].diff_id;
+
+  await agent
+    .post(`/apply_web_diff/${diffId}`)
+    .send({ action: 'approve' })
+    .expect(200);
+
+  const camp = await agent
+    .post('/record_campaign')
+    .send({ company_id: 'c1', brief: 'hi', message: 'hello' })
+    .expect(200);
+
+  const campaign = await Campaign.findOne({ campaign_id: camp.body.campaign_id });
+  await CampaignEvent.create({
+    campaign_id: campaign?._id,
+    company_id: campaign?.company_id,
+    type: 'reply',
+  });
+  await CampaignEvent.create({
+    campaign_id: campaign?._id,
+    company_id: campaign?.company_id,
+    type: 'click',
+  });
+
+  console.log('e2e flow completed');
+
+  await mongoose.disconnect();
+  await mongo.stop();
+}
+
+main();

--- a/server/tools.json
+++ b/server/tools.json
@@ -1,0 +1,129 @@
+[
+  {
+    "name": "save_company_profile",
+    "description": "Create or update a company profile",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "company_id": { "type": "string" },
+        "name": { "type": "string" },
+        "channels": { "type": "array", "items": { "type": "string" } },
+        "brand_tone": { "type": "string" },
+        "locales": { "type": "array", "items": { "type": "string" } },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "address": { "type": "string" },
+              "hours": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      },
+      "required": ["company_id", "name"]
+    }
+  },
+  {
+    "name": "save_customer",
+    "description": "Upsert customer for a company",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "customer_id": { "type": "string" },
+        "company_id": { "type": "string" },
+        "name": { "type": "string" },
+        "phone": { "type": "string" },
+        "email": { "type": "string" },
+        "opt_in": {
+          "type": "object",
+          "properties": {
+            "sms": { "type": "boolean" },
+            "sms_ts": { "type": "string", "format": "date-time" },
+            "email": { "type": "boolean" },
+            "email_ts": { "type": "string", "format": "date-time" }
+          }
+        }
+      },
+      "required": ["customer_id", "company_id"]
+    }
+  },
+  {
+    "name": "record_campaign",
+    "description": "Create a campaign",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "company_id": { "type": "string" },
+        "campaign_id": { "type": "string" },
+        "brief": { "type": "string" },
+        "message": { "type": "string" }
+      },
+      "required": ["company_id"]
+    }
+  },
+  {
+    "name": "record_campaign_results",
+    "description": "Update campaign results",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "campaign_id": { "type": "string" },
+        "replies_7d": { "type": "number" },
+        "clicks_7d": { "type": "number" },
+        "bookings_7d": { "type": "number" }
+      },
+      "required": ["campaign_id"]
+    }
+  },
+  {
+    "name": "start_web_enrichment",
+    "description": "Register sources and start web enrichment",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "company_id": { "type": "string" },
+        "sources": {
+          "type": "array",
+          "items": { "type": "object", "properties": { "kind": { "type": "string" }, "url": { "type": "string", "format": "uri" } }, "required": ["kind", "url"] }
+        }
+      },
+      "required": ["company_id", "sources"]
+    }
+  },
+  {
+    "name": "list_web_diffs",
+    "description": "List pending web diffs for a company",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "company_id": { "type": "string" }
+      },
+      "required": ["company_id"]
+    }
+  },
+  {
+    "name": "apply_web_diff",
+    "description": "Approve or reject a diff",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "diff_id": { "type": "string" },
+        "action": { "type": "string", "enum": ["approve", "reject"] }
+      },
+      "required": ["diff_id", "action"]
+    }
+  },
+  {
+    "name": "get_policy_status",
+    "description": "Get policy status for a channel",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "company_id": { "type": "string" },
+        "channel": { "type": "string" }
+      },
+      "required": ["company_id", "channel"]
+    }
+  }
+]

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "tests", "scripts", "worker"],
+  "ts-node": {
+    "swc": true
+  }
+}

--- a/server/worker/enrichment.ts
+++ b/server/worker/enrichment.ts
@@ -1,0 +1,35 @@
+import { load } from 'cheerio';
+import { randomUUID } from 'crypto';
+import { connect, disconnect } from '../src/db.js';
+import { Company, WebSource, WebDiff } from '../src/models/index.js';
+
+async function run() {
+  await connect();
+  const sources = await WebSource.find().lean();
+  for (const src of sources) {
+    try {
+      const res = await fetch(src.url);
+      const html = await res.text();
+      const $ = load(html);
+      const title = $('title').text();
+      const company = await Company.findById(src.company_id).lean();
+      const current = company?.web_enrichment?.title;
+      if (title && title !== current) {
+        await WebDiff.create({
+          diff_id: randomUUID(),
+          company_id: src.company_id,
+          source_id: src._id,
+          diff: { title },
+          status: 'pending',
+          detected_at: new Date(),
+        });
+      }
+      await WebSource.updateOne({ _id: src._id }, { last_checked: new Date() });
+    } catch (err) {
+      console.error('enrichment error', err);
+    }
+  }
+  await disconnect();
+}
+
+run();


### PR DESCRIPTION
## Summary
- set up TypeScript Node backend with Express and Mongoose models for companies, customers, campaigns and web enrichment
- add endpoints for saving profiles, running web enrichment and applying diffs
- include minimal enrichment worker, seed/init scripts and tools.json

## Testing
- `npm test` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30adfddbc832a89bd2a1a4dfa80ba