### PR TITLE
Use ts-node for server tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,14 +4,12 @@
   "type": "commonjs",
   "main": "dist/server.js",
   "scripts": {
-codex/develop-ai-chat-product-with-integrations-z3cluf
     "build": "tsc",
     "start": "node dist/server.js",
     "dev": "TS_NODE_TRANSPILE_ONLY=1 RUN_SERVER=1 ts-node src/server.ts",
-    "test": "node -e \"console.log('server tests skipped')\"",
+    "test": "ts-node tests/e2e.test.ts",
     "seed": "ts-node ../scripts/seed.ts"
   },
- main
   "dependencies": {
     "express": "^4.19.2",
     "mongoose": "^8.3.4",

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- run server tests with `ts-node`
- compile server TypeScript as CommonJS modules

## Testing
- `npm install --prefix server` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcheerio)*
- `npm test --prefix server` *(fails: ts-node: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4763cbf6c832ab5ca146ca25129d3