### PR TITLE
test: enable vitest in frontend

### DIFF
--- a/frontend/basic.test.ts
+++ b/frontend/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('basic test', () => {
+  it('runs', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node -e \"console.log('frontend tests skipped')\""
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "14.1.0",
@@ -18,6 +18,7 @@
   "devDependencies": {
     "typescript": "5.3.3",
     "eslint": "8.56.0",
-    "eslint-config-next": "14.1.0"
+    "eslint-config-next": "14.1.0",
+    "vitest": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- install vitest and wire up `npm test` in the frontend
- add a trivial sample test exercising the test runner

## Testing
- `npm install` (fails: No matching version found for openai@4.48.0)
- `npm test` (fails: vitest: not found)
- `cd server && npm test` (fails: Invalid package.json: JSONParseError)
- `pytest` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4763b6aa4832aa7b60fac410315e3