### PR TITLE
Use Next.js builder for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "frontend/**", "use": "@vercel/static" }
+    { "src": "frontend/next.config.js", "use": "@vercel/next" }
   ],
   "routes": [
     { "src": "/(.*)", "dest": "frontend/$1" }


### PR DESCRIPTION
## Summary
- configure Vercel to build the Next.js frontend with `@vercel/next`

## Testing
- `npm test` *(frontend, fails: vitest not found)*
- `npm test` *(server, fails: Module has no default export)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a774771108832aa5539beab19065ce