### PR TITLE
Use Next.js builder for Vercel deployment

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -61,18 +61,4 @@ export async function POST(req: NextRequest) {
   });
 
   return new Response(stream);
-
-export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const response = await openaiClient.chat.completions.create({
-    model: process.env.OPENAI_MODEL || 'gpt-4o',
-    stream: true,
-    messages: body.messages,
-  });
-
-  return new Response(response.toReadableStream(), {
-    headers: { 'Content-Type': 'text/event-stream' },
-  });
-}
-main
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "builds": [
-    { "src": "frontend/**", "use": "@vercel/static" }
+    { "src": "frontend/next.config.js", "use": "@vercel/next" }
   ],
   "routes": [
     { "src": "/(.*)", "dest": "frontend/$1" }


### PR DESCRIPTION
## Summary
- configure Vercel to build the Next.js frontend with `@vercel/next`
- remove duplicate POST handler in chat API to prevent 500 errors

## Testing
- `npm test` *(frontend, fails: vitest not found)*
- `npm test` *(server, fails: Module has no default export)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a774771108832aa5539beab19065ce