### PR TITLE
Add campaign event endpoint and snapshot support

### DIFF
--- a/server/src/initIndexes.ts
+++ b/server/src/initIndexes.ts
@@ -1,4 +1,4 @@
-import { Company, Customer, Campaign, CampaignEvent, CampaignResult, WebSource, WebDiff } from './models/index.js';
+import { Company, Customer, Campaign, CampaignEvent, CampaignResult, WebSource, WebDiff } from './models';
 
 export async function ensureIndexes() {
   await Promise.all([

--- a/server/src/policy.ts
+++ b/server/src/policy.ts
@@ -80,10 +80,10 @@ export function suggestNextAllowedTime(
   }
 }
 
-import { Company } from './models/index.js';
+import { Company } from './models';
 
 export async function getPolicyStatus(company_id: string, channel: string) {
-  const company = await Company.findOne({ company_id }).lean();
+  const company = (await Company.findOne({ company_id }).lean()) as any;
   if (!company) {
     throw new Error('company not found');
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { z } from 'zod';
-import { connect } from './db.js';
+import { connect } from './db';
 import {
   Company,
   Customer,
@@ -9,10 +9,10 @@ import {
   CampaignResult,
   WebSource,
   WebDiff,
-} from './models/index.js';
-import { ensureIndexes } from './initIndexes.js';
+} from './models';
+import { ensureIndexes } from './initIndexes';
 import { randomUUID } from 'crypto';
-import { getPolicyStatus } from './policy.js';
+import { getPolicyStatus } from './policy';
 
 const app = express();
 app.use(express.json());
@@ -91,8 +91,28 @@ const campaignSchema = z.object({
 app.post('/record_campaign', async (req, res) => {
   try {
     const data = campaignSchema.parse(req.body);
+    const company = (await Company.findOne({ company_id: data.company_id }).lean()) as any;
+    if (!company) return res.status(404).json({ error: 'company not found' });
+
     const campaign_id = data.campaign_id || randomUUID();
-    const campaign = await Campaign.create({ ...data, campaign_id });
+
+    const lastCampaign = await Campaign.findOne({ company_id: company._id })
+      .sort({ createdAt: -1 })
+      .lean();
+    let lastResult: any = null;
+    if (lastCampaign) {
+      lastResult = await CampaignResult.findOne({ campaign_id: lastCampaign._id }).lean();
+    }
+    const snapshot = { web_enrichment: company.web_enrichment, last_result: lastResult };
+
+    const campaign = (await Campaign.create({
+      campaign_id,
+      company_id: company._id,
+      brief: data.brief,
+      message: data.message,
+      snapshot,
+    })) as any;
+
     await CampaignEvent.create({
       campaign_id: campaign._id,
       company_id: campaign.company_id,
@@ -122,6 +142,31 @@ app.post('/record_campaign_results', async (req, res) => {
       { ...data, campaign_id: campaign._id },
       { upsert: true }
     );
+    res.json({ status: 'ok' });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+// record_campaign_event
+const eventSchema = z.object({
+  campaign_id: z.string(),
+  type: z.enum(['delivered', 'reply', 'click', 'booking']),
+  metadata: z.record(z.any()).optional(),
+});
+
+app.post('/record_campaign_event', async (req, res) => {
+  try {
+    const data = eventSchema.parse(req.body);
+    const campaign = (await Campaign.findOne({ campaign_id: data.campaign_id }).lean()) as any;
+    if (!campaign) return res.status(404).json({ error: 'campaign not found' });
+
+    await CampaignEvent.create({
+      campaign_id: campaign._id,
+      company_id: campaign.company_id,
+      type: data.type,
+      metadata: data.metadata,
+    });
     res.json({ status: 'ok' });
   } catch (err) {
     res.status(400).json({ error: (err as Error).message });
@@ -183,7 +228,7 @@ const applyDiffSchema = z.object({ action: z.enum(['approve', 'reject']) });
 app.post('/apply_web_diff/:id', async (req, res) => {
   try {
     const data = applyDiffSchema.parse(req.body);
-    const diff = await WebDiff.findOne({ diff_id: req.params.id });
+    const diff = (await WebDiff.findOne({ diff_id: req.params.id })) as any;
     if (!diff) return res.status(404).json({ error: 'diff not found' });
     diff.status = data.action === 'approve' ? 'approved' : 'rejected';
     if (data.action === 'approve') {
@@ -252,53 +297,6 @@ app.get('/get_company_snapshot', async (req, res) => {
     }
 
     res.json({ company, last_campaign: result });
-
-// find_customers
-const findCustomersSchema = z.object({
-  company_id: z.string(),
-  tags: z.union([z.string(), z.array(z.string())]).optional(),
-  opt_in_sms: z.coerce.boolean().optional(),
-});
-
-app.get('/find_customers', async (req, res) => {
-  try {
-    const data = findCustomersSchema.parse(req.query);
-    const company = await Company.findOne({ company_id: data.company_id }).lean();
-    if (!company) return res.status(404).json({ error: 'company not found' });
-
-    const query: any = { company_id: company._id };
-    const tags = Array.isArray(data.tags) ? data.tags : data.tags ? [data.tags] : undefined;
-    if (tags) query.tags = { $all: tags };
-    if (typeof data.opt_in_sms === 'boolean') {
-      query['opt_in_sms'] = data.opt_in_sms;
-    }
-
-    const customers = await Customer.find(query).lean();
-    res.json(customers);
-  } catch (err) {
-    res.status(400).json({ error: (err as Error).message });
-  }
-});
-// get_company_snapshot
-const snapshotSchema = z.object({ company_id: z.string() });
-
-app.get('/get_company_snapshot', async (req, res) => {
-  try {
-    const data = snapshotSchema.parse(req.query);
-    const company = await Company.findOne({ company_id: data.company_id }).lean();
-    if (!company) return res.status(404).json({ error: 'company not found' });
-
-    const lastCampaign = await Campaign.findOne({ company_id: company._id })
-      .sort({ createdAt: -1 })
-      .lean();
-
-    let result: any = null;
-    if (lastCampaign) {
-      result = await CampaignResult.findOne({ campaign_id: lastCampaign._id }).lean();
-    }
-
-    res.json({ company, last_campaign: result });
-main
   } catch (err) {
     res.status(400).json({ error: (err as Error).message });
   }

--- a/server/tests/e2e.test.ts
+++ b/server/tests/e2e.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import app from '../src/server';
-import { CampaignEvent, Campaign } from '../src/models/index.js';
+import { CampaignEvent, Campaign } from '../src/models';
 
 async function main() {
   const mongo = await MongoMemoryServer.create();
@@ -15,6 +15,11 @@ async function main() {
   await agent
     .post('/save_company_profile')
     .send({ company_id: 'c1', name: 'Acme' })
+    .expect(200);
+
+  await agent
+    .get('/get_policy_status')
+    .query({ company_id: 'c1', channel: 'sms' })
     .expect(200);
 
   for (let i = 0; i < 3; i++) {
@@ -62,16 +67,20 @@ async function main() {
     .expect(200);
 
   const campaign: any = await Campaign.findOne({ campaign_id: camp.body.campaign_id }).lean();
-  await CampaignEvent.create({
-    campaign_id: campaign?._id,
-    company_id: campaign?.company_id,
-    type: 'reply',
-  });
-  await CampaignEvent.create({
-    campaign_id: campaign?._id,
-    company_id: campaign?.company_id,
-    type: 'click',
-  });
+
+  await agent
+    .post('/record_campaign_event')
+    .send({ campaign_id: camp.body.campaign_id, type: 'reply' })
+    .expect(200);
+  await agent
+    .post('/record_campaign_event')
+    .send({ campaign_id: camp.body.campaign_id, type: 'click' })
+    .expect(200);
+
+  const evCount = await CampaignEvent.countDocuments({ campaign_id: campaign._id });
+  console.log('events logged', evCount);
+
+  console.log('snapshot title', campaign.snapshot?.web_enrichment?.title);
 
   const snapshot = await agent
     .get('/get_company_snapshot')

--- a/server/tools.json
+++ b/server/tools.json
@@ -78,6 +78,22 @@
     }
   },
   {
+    "name": "record_campaign_event",
+    "description": "Log a campaign event such as delivery or reply",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "campaign_id": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["delivered", "reply", "click", "booking"]
+        },
+        "metadata": { "type": "object", "additionalProperties": true }
+      },
+      "required": ["campaign_id", "type"]
+    }
+  },
+  {
     "name": "start_web_enrichment",
     "description": "Register sources and start web enrichment",
     "parameters": {


### PR DESCRIPTION
## Summary
- capture company snapshot when recording campaigns and log creation events
- add `record_campaign_event` endpoint and tools definition
- exercise policy check and event logging in E2E test

## Testing
- `npm test` *(fails: MongoMemoryServer missing libcrypto.so.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a863ecba18832a9d9b166a3b66afbb